### PR TITLE
Fix {tosca.datatypes.network}PortInfo

### DIFF
--- a/datatypes/tosca.datatypes.network/PortInfo/DataType.tosca
+++ b/datatypes/tosca.datatypes.network/PortInfo/DataType.tosca
@@ -2,16 +2,16 @@ tosca_definitions_version: tosca_simple_yaml_1_3
 data_types:
   tosca.datatypes.network.PortInfo:
     derived_from: tosca.datatypes.Root
-      properties:
-        port_name:
+    properties:
+      port_name:
+        type: string
+      port_id:
+        type: string
+      network_id:
+        type: string
+      mac_address:
+        type: string
+      addresses:
+        type: list
+        entry_schema:
           type: string
-        port_id:
-          type: string
-        network_id:
-          type: string
-        mac_address:
-          type: string
-        addresses:
-          type: list
-          entry_schema:
-            type: string


### PR DESCRIPTION
The properties of a DataType can not be nested into the derived_from declaration

- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)