### PR TITLE
Changed camel-case notation of EndPoint in remaining occurences to lower-case p.

### DIFF
--- a/nodetypes/radon.nodes.docker/DockerApplication/NodeType.tosca
+++ b/nodetypes/radon.nodes.docker/DockerApplication/NodeType.tosca
@@ -17,5 +17,5 @@ node_types:
           capability: tosca.capabilities.Storage
           occurrences: [ 0, 1 ]
       - network:
-          capability: tosca.capabilities.EndPoint
+          capability: tosca.capabilities.Endpoint
           occurrences: [ 0, 1 ]

--- a/nodetypes/radon.nodes.docker/DockerApplication/README.md
+++ b/nodetypes/radon.nodes.docker/DockerApplication/README.md
@@ -10,7 +10,7 @@
 |:---- |:--------------- |:-------------------- |:----------------- |:------------|
 | `host` | `radon.capabilities.container.DockerRuntime` | `node: tosca.nodes.Container.Runtime` | `tosca.relationships.HostedOn` | [1, 1] |
 | `storage` | `tosca.capabilities.Storage` | | | [0, 1] |
-| `network` | `tosca.capabilities.EndPoint` | | | [0, 1] |
+| `network` | `tosca.capabilities.Endpoint` | | | [0, 1] |
 
 ### Notes
 

--- a/nodetypes/tosca.nodes.Container/Application/NodeType.tosca
+++ b/nodetypes/tosca.nodes.Container/Application/NodeType.tosca
@@ -17,5 +17,5 @@ node_types:
           capability: tosca.capabilities.Storage
           occurrences: [ 1, 1 ]
       - network:
-          capability: tosca.capabilities.EndPoint
+          capability: tosca.capabilities.Endpoint
           occurrences: [ 1, 1 ]


### PR DESCRIPTION
Changed camel-case notation of EndPoint in remaining occurences to lower-case p.
radon-h2020/radon-gmt#22 
