### PR TITLE
radon-h2020/radon-ctt#60 Updated create.yml artifact to pull newest image

### DIFF
--- a/nodetypes/radon.nodes.testing/JMeter/files/create/create.yml
+++ b/nodetypes/radon.nodes.testing/JMeter/files/create/create.yml
@@ -18,6 +18,7 @@
       docker_container:
         name: JMeterAgent
         image: radonconsortium/radon-ctt-agent:jmeter
+        pull: yes
         ports: 
           - "5000:5000"
 


### PR DESCRIPTION
## Short Description

The create.yml for the JMeter CTT-Agent was altered to always pull the newest image instead of potentially using a stale image that is present on the system.

## Resolving Issue / Feature
Contributing to: radon-h2020/radon-ctt#60
