### PR TITLE
Use pip for installing awscli

### DIFF
--- a/nodetypes/radon.nodes.aws/AwsPlatform/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.aws/AwsPlatform/files/configure/configure.yml
@@ -3,8 +3,7 @@
   gather_facts: false
   tasks:
     - name: install awscli
-      become: yes
-      package:
+      pip:
         name: awscli
         state: present
     - name: install boto


### PR DESCRIPTION
Use pip for installing AWS CLI to avoid package manager-related errors