### PR TITLE
radon-h2020/radon-ctt#61 Added blueprint for JMeter test agent with EC2

### DIFF
--- a/policytypes/radon.policies.testing/Test/PolicyType.tosca
+++ b/policytypes/radon.policies.testing/Test/PolicyType.tosca
@@ -2,6 +2,7 @@ tosca_definitions_version: tosca_simple_yaml_1_3
 
 policy_types:
   radon.policies.testing.Test:
+    derived_from: tosca.policies.Root
     metadata:
       targetNamespace: "radon.policies.testing"
       abstract: "true"

--- a/servicetemplates/radon.blueprints.testing/DeploymentTestAgentEC2/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.testing/DeploymentTestAgentEC2/ServiceTemplate.tosca
@@ -54,10 +54,10 @@ topology_template:
         displayName: "EC2"
       properties:
         image: "ami-089cc16f7f08c4457"
-        ssh_key_name: "{{ get_input: ssh_key_name }}"
-        vpc_subnet_id: "{{ get_input: vpc_subnet_id }}"
+        ssh_key_name: { get_input: ssh_key_name }
+        vpc_subnet_id: { get_input: vpc_subnet_id }
         instance_type: "t2.micro"
-        ssh_key_file: "{{ get_input: ssh_key_file }}"
+        ssh_key_file: { get_input: ssh_key_file }
         ssh_user: "ubuntu"
       requirements:
         - host:

--- a/servicetemplates/radon.blueprints.testing/DeploymentTestAgentEC2/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.testing/DeploymentTestAgentEC2/ServiceTemplate.tosca
@@ -1,0 +1,62 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+metadata:
+  targetNamespace: "radon.blueprints.testing"
+topology_template:
+  node_templates:
+    DockerEngine_0:
+      type: radon.nodes.docker.DockerEngine
+      metadata:
+        x: "854"
+        y: "361"
+        displayName: "DockerEngine"
+      requirements:
+        - host:
+            node: EC2_0
+            relationship: con_HostedOn_1
+            capability: host
+    DeploymentTestAgent_0:
+      type: radon.nodes.testing.DeploymentTestAgent
+      metadata:
+        x: "589"
+        y: "359"
+        displayName: "DeploymentTestAgent"
+      requirements:
+        - host:
+            node: DockerEngine_0
+            relationship: con_HostedOn_2
+            capability: host
+    AwsPlatform_0:
+      type: radon.nodes.aws.AwsPlatform
+      metadata:
+        x: "1339"
+        y: "362"
+        displayName: "AwsPlatform"
+      properties:
+        name: "AWS"
+        region: "eu-west-1"
+    EC2_0:
+      type: radon.nodes.VM.EC2
+      metadata:
+        x: "1094"
+        y: "360"
+        displayName: "EC2"
+      properties:
+        image: "ami-089cc16f7f08c4457"
+        ssh_key_name: "{ get_input: ssh_key_name }"
+        vpc_subnet_id: "{ get_input: vpc_subnet_id }"
+        instance_type: "t2.micro"
+        ssh_key_file: "{ get_input: ssh_key_file }"
+        ssh_user: "ubuntu"
+      requirements:
+        - host:
+            node: AwsPlatform_0
+            relationship: con_HostedOn_0
+            capability: host
+  relationship_templates:
+    con_HostedOn_2:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_0:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_1:
+      type: tosca.relationships.HostedOn

--- a/servicetemplates/radon.blueprints.testing/DeploymentTestAgentEC2/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.testing/DeploymentTestAgentEC2/ServiceTemplate.tosca
@@ -3,6 +3,17 @@ tosca_definitions_version: tosca_simple_yaml_1_3
 metadata:
   targetNamespace: "radon.blueprints.testing"
 topology_template:
+  inputs:
+    ssh_key_name:
+      type: string
+      required: true
+    vpc_subnet_id:
+      type: string
+      description: AWS VPC Subnet ID
+      required: true
+    ssh_key_file:
+      type: string
+      required: true
   node_templates:
     DockerEngine_0:
       type: radon.nodes.docker.DockerEngine
@@ -43,10 +54,10 @@ topology_template:
         displayName: "EC2"
       properties:
         image: "ami-089cc16f7f08c4457"
-        ssh_key_name: "{ get_input: ssh_key_name }"
-        vpc_subnet_id: "{ get_input: vpc_subnet_id }"
+        ssh_key_name: "{{ get_input: ssh_key_name }}"
+        vpc_subnet_id: "{{ get_input: vpc_subnet_id }}"
         instance_type: "t2.micro"
-        ssh_key_file: "{ get_input: ssh_key_file }"
+        ssh_key_file: "{{ get_input: ssh_key_file }}"
         ssh_user: "ubuntu"
       requirements:
         - host:

--- a/servicetemplates/radon.blueprints.testing/JMeterMasterOnlyEC2/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.testing/JMeterMasterOnlyEC2/ServiceTemplate.tosca
@@ -52,10 +52,10 @@ topology_template:
         displayName: "EC2"
       properties:
         image: "ami-089cc16f7f08c4457"
-        ssh_key_name: "{{ get_input: ssh_key_name }}"
-        vpc_subnet_id: "{{ get_input: vpc_subnet_id }}"
+        ssh_key_name: { get_input: ssh_key_name }
+        vpc_subnet_id: { get_input: vpc_subnet_id }
         instance_type: "t2.micro"
-        ssh_key_file: "{{ get_input: ssh_key_file }}"
+        ssh_key_file: { get_input: ssh_key_file }
         ssh_user: "ubuntu"
       requirements:
         - host:

--- a/servicetemplates/radon.blueprints.testing/JMeterMasterOnlyEC2/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.testing/JMeterMasterOnlyEC2/ServiceTemplate.tosca
@@ -1,0 +1,62 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+metadata:
+  targetNamespace: "radon.blueprints.testing"
+topology_template:
+  node_templates:
+    DockerEngine_0:
+      type: radon.nodes.docker.DockerEngine
+      metadata:
+        x: "648"
+        y: "334"
+        displayName: "DockerEngine"
+      requirements:
+        - host:
+            node: EC2_0
+            relationship: con_HostedOn_1
+            capability: host
+    JMeter_0:
+      type: radon.nodes.testing.JMeter
+      metadata:
+        x: "209"
+        y: "328"
+        displayName: "JMeterMasterAgent"
+      requirements:
+        - host:
+            node: DockerEngine_0
+            relationship: con_HostedOn_0
+            capability: host
+    AwsPlatform_0:
+      type: radon.nodes.aws.AwsPlatform
+      metadata:
+        x: "1490"
+        y: "335"
+        displayName: "AwsPlatform"
+      properties:
+        name: "AWS"
+        region: "eu-west-1"
+    EC2_0:
+      type: radon.nodes.VM.EC2
+      metadata:
+        x: "1039"
+        y: "336"
+        displayName: "EC2"
+      properties:
+        image: "ami-089cc16f7f08c4457"
+        ssh_key_name: { get_input: ssh_key_name }
+        vpc_subnet_id: { get_input: vpc_subnet_id }
+        instance_type: "t2.micro"
+        ssh_key_file: { get_input: ssh_key_file }
+        ssh_user: "ubuntu"
+      requirements:
+        - host:
+            node: AwsPlatform_0
+            relationship: con_HostedOn_2
+            capability: host
+  relationship_templates:
+    con_HostedOn_2:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_0:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_1:
+      type: tosca.relationships.HostedOn

--- a/servicetemplates/radon.blueprints.testing/JMeterMasterOnlyEC2/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.testing/JMeterMasterOnlyEC2/ServiceTemplate.tosca
@@ -3,12 +3,22 @@ tosca_definitions_version: tosca_simple_yaml_1_3
 metadata:
   targetNamespace: "radon.blueprints.testing"
 topology_template:
+  inputs:
+    ssh_key_name:
+      type: string
+      required: true
+    vpc_subnet_id:
+      type: string
+      required: true
+    ssh_key_file:
+      type: string
+      required: true
   node_templates:
     DockerEngine_0:
       type: radon.nodes.docker.DockerEngine
       metadata:
-        x: "648"
-        y: "334"
+        x: "706"
+        y: "330"
         displayName: "DockerEngine"
       requirements:
         - host:
@@ -18,40 +28,39 @@ topology_template:
     JMeter_0:
       type: radon.nodes.testing.JMeter
       metadata:
-        x: "209"
-        y: "328"
-        displayName: "JMeterMasterAgent"
+        x: "370"
+        y: "344"
+        displayName: "JMeter"
       requirements:
         - host:
             node: DockerEngine_0
-            relationship: con_HostedOn_0
+            relationship: con_HostedOn_2
             capability: host
     AwsPlatform_0:
       type: radon.nodes.aws.AwsPlatform
       metadata:
-        x: "1490"
-        y: "335"
+        x: "1282"
+        y: "324"
         displayName: "AwsPlatform"
       properties:
         name: "AWS"
-        region: "eu-west-1"
     EC2_0:
       type: radon.nodes.VM.EC2
       metadata:
-        x: "1039"
-        y: "336"
+        x: "998"
+        y: "321"
         displayName: "EC2"
       properties:
         image: "ami-089cc16f7f08c4457"
-        ssh_key_name: { get_input: ssh_key_name }
-        vpc_subnet_id: { get_input: vpc_subnet_id }
+        ssh_key_name: "{{ get_input: ssh_key_name }}"
+        vpc_subnet_id: "{{ get_input: vpc_subnet_id }}"
         instance_type: "t2.micro"
-        ssh_key_file: { get_input: ssh_key_file }
+        ssh_key_file: "{{ get_input: ssh_key_file }}"
         ssh_user: "ubuntu"
       requirements:
         - host:
             node: AwsPlatform_0
-            relationship: con_HostedOn_2
+            relationship: con_HostedOn_0
             capability: host
   relationship_templates:
     con_HostedOn_2:


### PR DESCRIPTION
Based on the availability of a Docker engine on top of an EC2 instance, we created an initial version of the JMeter test agent on EC2.