### PR TITLE
Fix policy syntax in SockShopTestingExample

### DIFF
--- a/servicetemplates/radon.blueprints/SockShopTestingExample/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints/SockShopTestingExample/ServiceTemplate.tosca
@@ -27,35 +27,35 @@ topology_template:
     con_HostedOn_0:
       type: tosca.relationships.HostedOn
   policies:
-    SimplePingTest:
-      type: radon.policies.testing.PingTest
-      properties:
-        hostname: "localhost"
-        ti_blueprint: "radon.blueprints.testing.DeploymentTestAgent"
-        test_id: "pingtest_123"
-      targets: [ SockShop ]
-    SimpleEndpointTest:
-      type: radon.policies.testing.HttpEndpointTest
-      properties:
-        path: "/"
-        hostname: "localhost"
-        method: "GET"
-        expected_status: 200
-        port: 80
-        expected_body: null
-        ti_blueprint: "radon.blueprints.testing.DeploymentTestAgent"
-        use_https: false
-        test_id: "httptest_214"
-        test_header: null
-        test_body: null
-      targets: [ SockShop ]
-    SimpleJMeterLoadTest:
-      type: radon.policies.testing.JMeterLoadTest
-      properties:
-        hostname: "localhost"
-        jmx_file: "sockshop.jmx"
-        port: 8080
-        ti_blueprint: "radon.blueprints.testing.JMeterMasterOnly"
-        user.properties: null
-        test_id: "loadtest213"
-      targets: [ SockShop ]
+    - SimplePingTest:
+        type: radon.policies.testing.PingTest
+        properties:
+          hostname: "localhost"
+          ti_blueprint: "radon.blueprints.testing.DeploymentTestAgent"
+          test_id: "pingtest_123"
+        targets: [ SockShop ]
+    - SimpleEndpointTest:
+        type: radon.policies.testing.HttpEndpointTest
+        properties:
+          path: "/"
+          hostname: "localhost"
+          method: "GET"
+          expected_status: 200
+          port: 80
+          expected_body: null
+          ti_blueprint: "radon.blueprints.testing.DeploymentTestAgent"
+          use_https: false
+          test_id: "httptest_214"
+          test_header: null
+          test_body: null
+        targets: [ SockShop ]
+    - SimpleJMeterLoadTest:
+        type: radon.policies.testing.JMeterLoadTest
+        properties:
+          hostname: "localhost"
+          jmx_file: "sockshop.jmx"
+          port: 8080
+          ti_blueprint: "radon.blueprints.testing.JMeterMasterOnly"
+          user.properties: null
+          test_id: "loadtest213"
+        targets: [ SockShop ]


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files

## Short Description

The proposed changes fix the policies of the SockShopTestingExample, because they were saved as a map instead of a list of maps.

## Resolving Issue / Feature

Related to [OpenTOSCA PR #216](https://github.com/OpenTOSCA/winery/pull/216) and to [radon-gmt issue #47](https://github.com/radon-h2020/radon-gmt/issues/47)
