### PR TITLE
AwsPlatform nodetype refinement

### DIFF
--- a/nodetypes/radon.nodes.aws/AwsPlatform/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.aws/AwsPlatform/files/configure/configure.yml
@@ -7,21 +7,25 @@
       pip:
         name: awscli
         state: present
+        extra_args: --user
 
     - name: install boto
       pip:
         name: boto
         state: present
+        extra_args: --user
 
     - name: install boto3
       pip:
         name: boto3
-        state: present   
+        state: present
+        extra_args: --user   
      
     - name: install botocore
       pip:
         name: botocore
         state: present
+        extra_args: --user
 
     - name: Create global AWS role
       iam_role:


### PR DESCRIPTION
AwsPlatform nodetype refinement so that the packages are installed in the user's directory.

This PR solves the issue #69 