### PR TITLE
radon-h2020/radon-ctt#95 Add endpoint_url attribute to the AwsApiGateway

### DIFF
--- a/nodetypes/radon.nodes.aws/AwsApiGateway/NodeType.tosca
+++ b/nodetypes/radon.nodes.aws/AwsApiGateway/NodeType.tosca
@@ -10,6 +10,8 @@ node_types:
     attributes:
       arn:
         type: string
+      endpoint_url: 
+        type: string
     properties:
       api_title:
         type: string

--- a/nodetypes/radon.nodes.aws/AwsApiGateway/README.md
+++ b/nodetypes/radon.nodes.aws/AwsApiGateway/README.md
@@ -14,6 +14,8 @@ A node type that represents an AWS Lambda Function.
 | Name | Type | Default Value | Description |
 |:---- |:---- |:------------- |:----------- |
 | `arn` | `string` |   | Amazon's resource name for this entity |
+| `endpoint_url` | `string` |   | Base URL for endpoints provided by this API |
+
 
 ### Properties
 

--- a/nodetypes/radon.nodes.aws/AwsApiGateway/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.aws/AwsApiGateway/files/configure/configure.yml
@@ -1,9 +1,16 @@
 ---
 - hosts: all
+  vars:
+    api_gw_stage: "production"
   tasks:
     - name: Deploy API gateway
       aws_api_gateway:
         state: present
         swagger_file: "/tmp/swagger.json"
-        stage: production
+        stage: "{{ api_gw_stage }}"
         region: "{{ aws_region }}"
+      register: api_gw
+    - name: Set attributes
+      set_stats:
+        data:
+          endpoint_url: "https://{{ api_gw.api_id }}.execute-api.{{ aws_region }}.amazonaws.com/{{ api_gw_stage }}"


### PR DESCRIPTION
This PR adds another attribute to the AwsAPIGateway node type in the particles.
This attribute named `endpoint_url` exposes the base URL of the gateway.