### PR TITLE
Fix for JMeter ansible playbook, Docker Engine fixes.

### DIFF
--- a/nodetypes/radon.nodes.aws/AwsApiGateway/NodeType.tosca
+++ b/nodetypes/radon.nodes.aws/AwsApiGateway/NodeType.tosca
@@ -10,6 +10,8 @@ node_types:
     attributes:
       arn:
         type: string
+      endpoint_url: 
+        type: string
     properties:
       api_title:
         type: string

--- a/nodetypes/radon.nodes.aws/AwsApiGateway/README.md
+++ b/nodetypes/radon.nodes.aws/AwsApiGateway/README.md
@@ -14,6 +14,8 @@ A node type that represents an AWS Lambda Function.
 | Name | Type | Default Value | Description |
 |:---- |:---- |:------------- |:----------- |
 | `arn` | `string` |   | Amazon's resource name for this entity |
+| `endpoint_url` | `string` |   | Base URL for endpoints provided by this API |
+
 
 ### Properties
 

--- a/nodetypes/radon.nodes.aws/AwsApiGateway/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.aws/AwsApiGateway/files/configure/configure.yml
@@ -1,9 +1,16 @@
 ---
 - hosts: all
+  vars:
+    api_gw_stage: "production"
   tasks:
     - name: Deploy API gateway
       aws_api_gateway:
         state: present
         swagger_file: "/tmp/swagger.json"
-        stage: production
+        stage: "{{ api_gw_stage }}"
         region: "{{ aws_region }}"
+      register: api_gw
+    - name: Set attributes
+      set_stats:
+        data:
+          endpoint_url: "https://{{ api_gw.api_id }}.execute-api.{{ aws_region }}.amazonaws.com/{{ api_gw_stage }}"

--- a/nodetypes/radon.nodes.docker/DockerEngine/files/create/create.yml
+++ b/nodetypes/radon.nodes.docker/DockerEngine/files/create/create.yml
@@ -5,6 +5,11 @@
   become: yes
 
   tasks:
+    - name: Prerequirements for apt module
+      shell:
+        cmd: apt-get update && apt-get install python3-apt
+      when: ansible_os_family == "Debian"
+
     - name: Install required packages
       apt:
         pkg:
@@ -19,17 +24,20 @@
       apt_key:
         url: https://download.docker.com/linux/{{ ansible_distribution|lower }}/gpg
         id: 0EBFCD88
-        state: present  
+        state: present 
+      when: ansible_os_family == "Debian"
 
     - name: Add Docker repository
       apt_repository:
         filename: docker
         repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} stable
         update_cache: yes  
+      when: ansible_os_family == "Debian"
 
     - name: Install docker-ce
       apt:
         name: docker-ce  
+      when: ansible_os_family == "Debian"
 
     - name: Start and enable docker service
       service: 

--- a/nodetypes/radon.nodes.testing/JMeter/files/create/create.yml
+++ b/nodetypes/radon.nodes.testing/JMeter/files/create/create.yml
@@ -1,5 +1,5 @@
 - name: create
-  hosts: localhost
+  hosts: all
   gather_facts: yes
   tasks:
     - name: Install Python pip module prerequisites (Linux)

--- a/servicetemplates/radon.blueprints.testing/JMeterMasterOnlyEC2/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.testing/JMeterMasterOnlyEC2/ServiceTemplate.tosca
@@ -13,6 +13,12 @@ topology_template:
     ssh_key_file:
       type: string
       required: true
+  outputs:
+    public_address:
+      type: string
+      value: { get_attribute: [ EC2_0, public_address ] }
+      required: true
+      description: Address of the deployed EC2 instance running the JMeterTestAgent
   node_templates:
     DockerEngine_0:
       type: radon.nodes.docker.DockerEngine


### PR DESCRIPTION
- Add endpoint_url attribute to the AwsApiGateway nodetype.
- Extension of Docker engine create.yml
- Fix for wrong hosts definition in JMeter create.yml
- Add 'public_address' output to JMeterMasterEC2 service template