### PR TITLE
Adjusted GCS Datapipeline Node type 

### DIFF
--- a/nodetypes/radon.nodes.datapipeline.destination/PubGCS/NodeType.tosca
+++ b/nodetypes/radon.nodes.datapipeline.destination/PubGCS/NodeType.tosca
@@ -65,5 +65,5 @@ node_types:
         type: tosca.artifacts.File
         file: create.yml
       configure:
-        type: radon.artifacts.Ansible
+        type: tosca.artifacts.File
         file: configure.yml

--- a/nodetypes/radon.nodes.datapipeline.source/ConsGCSBucket/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsGCSBucket/files/configure/configure.yml
@@ -18,9 +18,9 @@
 ---
 - hosts: all
   vars:
-    get_id1: "processors[0].id"
+    get_id1: "processors[?component.name=='ListGCSBucket'].id"  
     # This will return the putlambda processor id (not the other processors)
-    get_id2: "processors[1].id"
+    #get_id2: ""processors[?component.name==''].id""
     dest_cred_file_path: "/tmp/.opera/gcs/cred"
     port: "{{ (lookup('file', '/tmp/nifi.json') | from_json) | default('8080', true)}}"
   tasks:
@@ -47,7 +47,7 @@
 
     - name: Configure the first processor within the process group
       vars:
-        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1) }}"
+        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1) | first }}"
         schedulingPeriodValue: "{{ '0 sec' if schedulingStrategy == 'EVENT_DRIVEN' else schedulingPeriodCRON }}"
         schedulingStrategyValue: "{{ 'TIMER_DRIVEN' if schedulingStrategy == 'EVENT_DRIVEN' else schedulingStrategy }}"
       uri:
@@ -71,7 +71,7 @@
 
     - name: Get id of the first processor within the process group.
       vars:
-        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1) }}"
+        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1) | first }}"
       uri:
         url: "http://localhost:{{port}}/nifi-api/processors/{{first_prcsr_id}}"
         method: Get

--- a/servicetemplates/radon.blueprints.examples/GCS_Object_Datapipeline_Example/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.examples/GCS_Object_Datapipeline_Example/ServiceTemplate.tosca
@@ -1,0 +1,83 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+metadata:
+  targetNamespace: "radon.blueprints.examples"
+topology_template:
+  node_templates:
+    ConsGCSBucket_0:
+      type: radon.nodes.datapipeline.source.ConsGCSBucket
+      metadata:
+        x: "358"
+        y: "96"
+        displayName: "ConsGCSBucket"
+      properties:
+        bucket: "radongcs"
+        project_ID: "radon-825040-utr "
+        schedulingStrategy: "EVENT_DRIVEN"
+        schedulingPeriodCRON: "* * * * * ?"
+        name: "ConsGCS"
+        credential_JSON_file: "/home/ubuntu/radon-825040-utr-a47a92d70742.json"
+      requirements:
+        - connectToPipeline:
+            node: PubGCS_0
+            relationship: con_ConnectNifiLocal_0
+            capability: ConnectToPipelineRemote
+        - host:
+            node: Nifi_0
+            relationship: con_HostedOn_1
+            capability: host
+    PubGCS_0:
+      type: radon.nodes.datapipeline.destination.PubGCS
+      metadata:
+        x: "970"
+        y: "95"
+        displayName: "PubGCS"
+      properties:
+        BucketName: "gcsradon"
+        cred_file_path: "/home/ubuntu/radon-825040-utr-a47a92d70742.json"
+        schedulingStrategy: "EVENT_DRIVEN"
+        ProjectID: "radon-825040-utr "
+        schedulingPeriodCRON: "* * * * * ?"
+        name: "PubsGCS"
+      requirements:
+        - host:
+            node: Nifi_0
+            relationship: con_HostedOn_2
+            capability: host
+    OpenStack_0:
+      type: radon.nodes.VM.OpenStack
+      metadata:
+        x: "659"
+        y: "367"
+        displayName: "OpenStack"
+      properties:
+        flavor: "6b254b9e-db1c-40de-994c-07d69dd732a6"
+        key_name: "Guha_Roy_RADON"
+        image: "13a94b11-98ee-43a4-ad29-00ae97e8f790"
+        ssh_username: "centos"
+        name: "GCS_Object_Datapipeline_Deep"
+        network: "provider_64_net"
+    Nifi_0:
+      type: radon.nodes.nifi.Nifi
+      metadata:
+        x: "660"
+        y: "214"
+        displayName: "Nifi"
+      properties:
+        port: 8080
+        webinterface_public: true
+        component_version: "1.13.2"
+      requirements:
+        - host:
+            node: OpenStack_0
+            relationship: con_HostedOn_0
+            capability: host
+  relationship_templates:
+    con_HostedOn_2:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_0:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_1:
+      type: tosca.relationships.HostedOn
+    con_ConnectNifiLocal_0:
+      type: radon.relationships.datapipeline.ConnectNifiLocal


### PR DESCRIPTION
TOSCA node types are adjusted, listed below:
1.	ConsGCSBucket
Under radon.nodes.datapipeline.source Namespace
2.	PubGCS
Under radon.nodes.datapipeline.destination Namespace
Created and added one new service template Example with these above-mentioned 2 node types to check, node types are working well or not.
That service template is under radon.blueprints.examples named as 
1)	GCS_Object_Datapipeline_Example
Tested with this command :
curl -d "" http://{{My IP}}:{{Port}}/winery/admin/repository/touch
with No error.
This is the part of UTR contribution.
