### PR TITLE
Fix the IAM role issue for Lambda functions

### DIFF
--- a/nodetypes/radon.nodes.aws/AwsPlatform/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.aws/AwsPlatform/files/configure/configure.yml
@@ -39,7 +39,11 @@
         state: present
         assume_role_policy_document: "{{ lookup('file','policy.json') }}"
         managed_policy:
-          - arn:aws:iam::aws:policy/AWSLambdaFullAccess
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+          - arn:aws:iam::aws:policy/AWSLambda_FullAccess
+          - arn:aws:iam::aws:policy/AmazonS3FullAccess
+          - arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess
+          - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
       register: iam_role_response
     - name: Set attributes
       set_stats:

--- a/nodetypes/radon.nodes.aws/AwsPlatform/files/policy/policy.json
+++ b/nodetypes/radon.nodes.aws/AwsPlatform/files/policy/policy.json
@@ -4,7 +4,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": ["lambda.amazonaws.com", "apigateway.amazonaws.com", "dynamodb.amazonaws.com"]
+        "Service": ["lambda.amazonaws.com", "apigateway.amazonaws.com"]
       },
       "Action": "sts:AssumeRole"
     }

--- a/relationshiptypes/radon.relationships.aws/AwsTriggers/files/event-binding.yml
+++ b/relationshiptypes/radon.relationships.aws/AwsTriggers/files/event-binding.yml
@@ -4,7 +4,7 @@
     - name: Set bucket notification
       s3_bucket_notification:
         state: present
-        event_name: "radon_on_jpg_add"
+        event_name: "radon_on_object_operation"
         bucket_name: "{{ bucket_name }}"
         lambda_function_arn: "{{ function_arn }}"
         events: ["{{ events }}"]


### PR DESCRIPTION
<!--
  For work in progress add the prefix [WIP] to the PR name
  After finishing the work remove the prefix and ensure that the following sections are filled correctly
-->

<!-- Before writing the PR please check the following --->

- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files

---

## Short Description

<!-- Summarize the new functionalities/fixes -->
This pull request aims to fix the IAM role issue for Lambda functions.

## Resolving Issue / Feature

<!-- Reference to the respective issue -->
An IAM role with `AWSLambdaFullAccess` is used to grant Lambda functions full access to AWS services. However, this policy is deprecated and replaced by `AWSLambda_FullAccess` (see [[1]](https://docs.aws.amazon.com/lambda/latest/dg/security_iam_troubleshoot.html#security_iam_troubleshoot-admin-deprecation)), which causes failure in deploying any RADON models with Lambda functions. To fix this issue, a list of nominally disjoint policies are combined to create the global IAM role. Supporting others AWS services accessible by Lambda functions would require extending the new IAM role with more policies.
