### PR TITLE
Correct TOSCA types for Azure nodes and relationships

### DIFF
--- a/nodetypes/radon.nodes.azure/AzureFunction/NodeType.tosca
+++ b/nodetypes/radon.nodes.azure/AzureFunction/NodeType.tosca
@@ -25,7 +25,7 @@ node_types:
         required: true
         description: The identifier for Azure region in which resources are/will be deployed
       functions_version:
-        type: int
+        type: integer
         required: false
         description: The version of the Azure function app
         default: 3
@@ -94,7 +94,7 @@ node_types:
             description: The identifier for Azure region in which resources are/will be deployed
             default: { get_property: [ SELF, region ] }
           functions_version:
-            type: int
+            type: integer
             required: false
             description: The version of the Azure function app
             default: { get_property: [ SELF, functions_version ] }

--- a/relationshiptypes/radon.relationships.azure/AzureContainerTriggers/RelationshipType.tosca
+++ b/relationshiptypes/radon.relationships.azure/AzureContainerTriggers/RelationshipType.tosca
@@ -53,8 +53,8 @@ relationship_types:
         required: true
         description: The name of the existing Azure function to set up trigger for
     interfaces:
-      Standard:
-        type: tosca.interfaces.node.lifecycle.Standard
+      Configure:
+        type: tosca.interfaces.relationship.Configure
         inputs:
           event_subscription_name:
             type: string


### PR DESCRIPTION
With this PR I'm correcting some simple TOSCA typing mistakes for the following nodes and relationships:

- `radon.nodes.azure.AzureFunction`
- `radon.relationships.azure.AzureContainerTriggers`