### PR TITLE
Fix monitoring namespaces

### DIFF
--- a/capabilitytypes/radon.capabilities.monitoring/Monitor/CapabilityType.tosca
+++ b/capabilitytypes/radon.capabilities.monitoring/Monitor/CapabilityType.tosca
@@ -4,6 +4,6 @@ capability_types:
   radon.capabilities.monitoring.Monitor:
     derived_from: tosca.capabilities.Root
     metadata:
-      targetNamespace: "radon.capabilities"
+      targetNamespace: "radon.capabilities.monitoring"
       abstract: "false"
       final: "false"

--- a/interfacetypes/radon.interfaces.scaling/ScaleUp/InterfaceType.tosca
+++ b/interfacetypes/radon.interfaces.scaling/ScaleUp/InterfaceType.tosca
@@ -2,6 +2,8 @@ tosca_definitions_version: tosca_simple_yaml_1_3
 interface_types:
   radon.interfaces.scaling.ScaleUp:
     derived_from: tosca.interfaces.Root
+    metadata:
+      targetNamespace: "radon.interfaces.scaling"
     operations:
       scale_up:
         description: Interface to trigger the scale up action

--- a/nodetypes/radon.nodes.aws/AwsLambdaFunctionFromS3Scalable/files/scaleUp/scaleUp.yml.mimetype
+++ b/nodetypes/radon.nodes.aws/AwsLambdaFunctionFromS3Scalable/files/scaleUp/scaleUp.yml.mimetype
@@ -1,0 +1,1 @@
+text/plain

--- a/relationshiptypes/radon.relationships.monitoring/AWSIsMonitoredBy/RelationshipType.tosca
+++ b/relationshiptypes/radon.relationships.monitoring/AWSIsMonitoredBy/RelationshipType.tosca
@@ -4,7 +4,7 @@ relationship_types:
   radon.relationships.monitoring.AWSIsMonitoredBy:
     derived_from: tosca.relationships.ConnectsTo
     metadata:
-      targetNamespace: "radon.relationships"
+      targetNamespace: "radon.relationships.monitoring"
       abstract: "false"
       final: "false"
     interfaces:

--- a/relationshiptypes/radon.relationships.monitoring/GCPIsMonitoredBy/RelationshipType.tosca
+++ b/relationshiptypes/radon.relationships.monitoring/GCPIsMonitoredBy/RelationshipType.tosca
@@ -4,7 +4,7 @@ relationship_types:
   radon.relationships.monitoring.GCPIsMonitoredBy:
     derived_from: tosca.relationships.ConnectsTo
     metadata:
-      targetNamespace: "radon.relationships"
+      targetNamespace: "radon.relationships.monitoring"
       abstract: "false"
       final: "false"
     interfaces:


### PR DESCRIPTION
This PR fixes `targetNamespace` values in monitoring-related types